### PR TITLE
Add rofi-power-menu mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ A curated list of awesome [rofi](https://github.com/DaveDavenport/rofi) (and dme
   Frontend for [Pass](https://www.passwordstore.org/)
 - [rofi-power](https://github.com/cjbassi/rofi-power) -
   Perform systemd based power management
+- [rofi-power-menu](https://github.com/jluttine/rofi-power-menu) - Mode for systemd-based power management
 - [rofi-themes](https://github.com/DaveDavenport/rofi-themes)
 - [udiskie-dmenu](https://github.com/fogine/udiskie-dmenu) -
   [udiskie](https://github.com/coldfix/udiskie) frontend for managing removable media


### PR DESCRIPTION
Hi! I wrote a simple power menu mode for Rofi so I thought I'd share it here if you want to include it. I know there are many similar rofi menus available but I couldn't find any other that was implemented as a rofi mode instead of a stand-alone executable that launches rofi by itself. For me personally, at least, this was important.